### PR TITLE
Fix try..catch block so that errors are sent back to the caller

### DIFF
--- a/src/lib/kubernetes.ts
+++ b/src/lib/kubernetes.ts
@@ -131,7 +131,6 @@ export const getKubernetesAccess = async (
 			return await linkToCluster.run(async ({ kubeconfig }) => {
 				const tempFiles = temp.track();
 				config.kubeconfig = tempFiles.path();
-				let result = null;
 
 				try {
 					await fs.writeFile(
@@ -145,13 +144,11 @@ export const getKubernetesAccess = async (
 
 					const boundFn = fn.bind({ accessConfig: config, kubeconfig });
 
-					result = await boundFn(client);
+					return await boundFn(client);
 				} finally {
 					// tidy up
 					await fs.writeFile(config.kubeconfig, '');
 					await Bluebird.fromCallback(callback => tempFiles.cleanup(callback));
-
-					return result;
 				}
 			});
 		},


### PR DESCRIPTION
Authentication errors against an AWS managed k8s cluster were silenced because there was no `catch` block and the error thrown by `boundFn` was ignored
This change allows the caller to be aware of the error and to handle it

Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
