### PR TITLE
Disable balenaci build steps

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,3 @@
+---
+npm:
+  run: false


### PR DESCRIPTION
Now that circleci has been wired up, we don't need to see those build failures from balenaci

Change-type: patch
Signed-off-by: Federico Fissore <federico@balena.io>
