### PR TITLE
Small improvements to test Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,6 @@ release/
 /test/external/*
 !/test/external/README.md
 
-lib
+/lib
 oclif.manifest.json
 tsconfig.tsbuildinfo

--- a/test/scripts/Dockerfile.tests
+++ b/test/scripts/Dockerfile.tests
@@ -1,4 +1,6 @@
-FROM node:latest
+FROM node:alpine
+
+RUN apk update && apk add curl
 
 WORKDIR /usr/src/app
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl && \
@@ -11,4 +13,4 @@ RUN npm ci
 
 COPY . .
 
-CMD [ "bash", "-c", "--", "while true; do sleep 1; done" ]
+CMD [ "ash", "-c", "while true; do sleep 1; done" ]

--- a/test/scripts/Dockerfile.tests
+++ b/test/scripts/Dockerfile.tests
@@ -7,7 +7,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.0/b
 
 COPY package* ./
 
-RUN npm i
+RUN npm ci
 
 COPY . .
 


### PR DESCRIPTION
- ~Downloads latest available `kubectl` rather than a fixed version~
- Install node deps using `npm ci` rather than `npm i`, so package-lock.json is used
- Use `node:alpine` so the job on circleci takes less